### PR TITLE
STA_SET_EAPTLS: struct missing elements username and micalg

### DIFF
--- a/inc/wfa_cmds.h
+++ b/inc/wfa_cmds.h
@@ -95,11 +95,13 @@ typedef struct ca_sta_set_eaptls
 {
     char intf[WFA_IF_NAME_LEN];
     char ssid[WFA_SSID_NAME_LEN];
+    char username[32];
     char keyMgmtType[8];
     char encrptype[9];
     char trustedRootCA[128];
     char clientCertificate[128];
     int pmf;               /* PMF enable or disable */
+    char micAlg[16];
 } caStaSetEapTLS_t;
 
 typedef struct ca_sta_set_eapttls

--- a/lib/wfa_cmdproc.c
+++ b/lib/wfa_cmdproc.c
@@ -1380,7 +1380,7 @@ int xcCmdProcStaSetEapTLS(char *pcmdStr, BYTE *aBuf, int *aLen)
     caStaSetEapTLS_t *setsec = (caStaSetEapTLS_t *) (aBuf+sizeof(wfaTLV));
 #ifndef WFA_PC_CONSOLE
     char *str;
-    caStaSetEapTLS_t defparams = {"", "", "", "", "", ""};
+    caStaSetEapTLS_t defparams = {"", "", "", "", "", "", "", 0, ""};
 
     if(aBuf == NULL)
         return WFA_FAILURE;

--- a/lib/wfa_cmdproc.c
+++ b/lib/wfa_cmdproc.c
@@ -1404,6 +1404,11 @@ int xcCmdProcStaSetEapTLS(char *pcmdStr, BYTE *aBuf, int *aLen)
             str = strtok_r(NULL, ",", &pcmdStr);
             strncpy(setsec->ssid, str, 64);
         }
+        else if(strcasecmp(str, "username") == 0)
+        {
+            str = strtok_r(NULL, ",", &pcmdStr);
+            strcpy(setsec->username, str);
+        }
         else if(strcasecmp(str, "keyMgmtType") == 0)
         {
             str=strtok_r(NULL, ",", &pcmdStr);
@@ -1439,6 +1444,14 @@ int xcCmdProcStaSetEapTLS(char *pcmdStr, BYTE *aBuf, int *aLen)
                 setsec->pmf = WFA_F_DISABLED;
             else
                 setsec->pmf = WFA_DISABLED;
+        }
+        else if(strcasecmp(str, "micAlg") == 0)
+        {
+            str = strtok_r(NULL, ",", &pcmdStr);
+            if(strcasecmp(str, "SHA-1") != 0)
+                strncpy(setsec->micAlg, str, 15);
+            else
+                strncpy(setsec->micAlg, "SHA-1", 15);
         }
     }
 


### PR DESCRIPTION
Structure ca_sta_set_eaptls is missing optional elements Username
and micAlg as defined in CAPI spec v8.3.1.

UCC scripts 11N are using Username in command sta_set_eaptls.

Signed-off-by: Cedric Baudelet <cedric.baudelet@intel.com>