### PR TITLE
STA_P2P_DISSOLVE: Corrected size given as argument of wfaEncodeTLV()

### DIFF
--- a/lib/wfa_cmdproc.c
+++ b/lib/wfa_cmdproc.c
@@ -2583,7 +2583,7 @@ int xcCmdProcStaP2pDissolve(char *pcmdStr, BYTE *aBuf, int *aLen)
         }
     }
 
-    wfaEncodeTLV(WFA_STA_P2P_DISSOLVE_TLV, sizeof(dutCommand_t), (BYTE *)staP2pDissolve, aBuf);
+    wfaEncodeTLV(WFA_STA_P2P_DISSOLVE_TLV, sizeof(caStaP2pDissolve_t), (BYTE *)staP2pDissolve, aBuf);
 
     *aLen = 4+sizeof(caStaP2pDissolve_t);
 


### PR DESCRIPTION
Was sizeof(dutCommand_t), updated to sizeof(caStaP2pDissolve_t)

Signed-off-by: Cedric Baudelet <cedric.baudelet@intel.com>