### PR TITLE
DEV_SEND_FRAME: Use 'type' instead of 'framename' for TDLS

### DIFF
--- a/lib/wfa_cmdproc.c
+++ b/lib/wfa_cmdproc.c
@@ -4037,7 +4037,7 @@ int xcCmdProcStaDevSendFrame(char *pcmdStr, BYTE *aBuf, int *aLen)
                     if(str == NULL || str[0] == '\0')
                         break;
 
-                    if (strcasecmp(str, "framename") == 0)
+                    if (strcasecmp(str, "type") == 0)
                     {
                         str = strtok_r(NULL, ",", &pcmdStr);
                         if (strcasecmp(str, "discovery") == 0)


### PR DESCRIPTION
Signed-off-by: Cedric Baudelet <cedric.baudelet@intel.com>