### PR TITLE
STA_RESET_DEFAULT: Add parsing of 'type' parameter

### DIFF
--- a/inc/wfa_cmds.h
+++ b/inc/wfa_cmds.h
@@ -1465,6 +1465,7 @@ typedef struct ca_sta_reset_default
 {
     char intf[WFA_IF_NAME_LEN];
     char prog[8];
+    char type[8];
 } caStaResetDefault_t;
 
 typedef struct ca_dev_info

--- a/lib/wfa_cmdproc.c
+++ b/lib/wfa_cmdproc.c
@@ -5272,12 +5272,12 @@ int xcCmdProcStaResetDefault(char *pcmdStr, BYTE *aBuf, int *aLen)
         else if(strcasecmp(str, "prog") == 0) // VHT, 11n, VOE; HS2; HS2-R2, etc
         {
             str = strtok_r(NULL, ",", &pcmdStr);
-            strncpy(reset->prog, str, 8);
+            strncpy(reset->prog, str, sizeof(reset->prog));
         }
         else if(strcasecmp(str, "type") == 0) // dut or sta
         {
            str = strtok_r(NULL, ",", &pcmdStr);
-            strncpy(reset->prog, str, 8);
+            strncpy(reset->type, str, sizeof(reset->type));
         }
     }
 


### PR DESCRIPTION
Type is part of STA_RESET_DEFAULT as defnied in CAPI spec 8.3.1.
It is used in Sigma-NAN testbed.

Signed-off-by: Cedric Baudelet <cedric.baudelet@intel.com>