### PR TITLE
STA_SET_RFEATURE: Add parameters used by TDLS testbed

### DIFF
--- a/inc/wfa_cmds.h
+++ b/inc/wfa_cmds.h
@@ -1496,6 +1496,9 @@ typedef struct ca_sta_rfeature
     wfaEnableType uapsd;
     char peer[18]; /* peer mac addr */
     wfaEnableType tpktimer;
+    char chswitchmode[16];
+    int offchnum;
+    char secchoffset[16];
 } caStaRFeat_t;
 
 typedef struct ca_sta_exec_action

--- a/lib/wfa_cmdproc.c
+++ b/lib/wfa_cmdproc.c
@@ -5718,6 +5718,21 @@ int xcCmdProcStaSetRFeature(char *pcmdStr, BYTE *aBuf, int *aLen)
             else
                 rfeat->tpktimer = eDisable;
         }
+        else if(strcasecmp(str, "ChSwitchMode") == 0)
+        {
+            str = strtok_r(NULL, ",", &pcmdStr);
+            strncpy(rfeat->chswitchmode, str, sizeof(rfeat->chswitchmode));
+        }
+        else if(strcasecmp(str, "OffChNum") == 0)
+        {
+            str = strtok_r(NULL, ",", &pcmdStr);
+            rfeat->offchnum = atoi(str);
+        }
+        else if(strcasecmp(str, "SecChOffset") == 0)
+        {
+            str = strtok_r(NULL, ",", &pcmdStr);
+            strncpy(rfeat->secchoffset, str, sizeof(rfeat->secchoffset));
+        }
     }
 
     wfaEncodeTLV(WFA_STA_SET_RFEATURE_TLV, sizeof(caStaRFeat_t), (BYTE *)rfeat, aBuf);


### PR DESCRIPTION
Add following parameters:
- ChSwithMode
- OffChNum
- SecChOffset

Signed-off-by: Cedric Baudelet <cedric.baudelet@intel.com>