### PR TITLE
Correct TLV type sent in xcCmdProcStaBlockICMPResponse()

### DIFF
--- a/lib/wfa_cmdproc.c
+++ b/lib/wfa_cmdproc.c
@@ -3280,7 +3280,7 @@ int xcCmdProcStaBlockICMPResponse(char *pcmdStr, BYTE *aBuf, int *aLen)
         }
     }
 
-    wfaEncodeTLV(WFA_STA_P2P_ADD_ARP_TABLE_ENTRY_TLV, sizeof(caStaBlockICMPResponse_t), (BYTE *)staBlockICMPResponse, aBuf);
+    wfaEncodeTLV(WFA_STA_P2P_BLOCK_ICMP_RESPONSE_TLV, sizeof(caStaBlockICMPResponse_t), (BYTE *)staBlockICMPResponse, aBuf);
 
     *aLen = 4+sizeof(caStaBlockICMPResponse_t);
 


### PR DESCRIPTION
Signed-off-by: Cedric Baudelet <cedric.baudelet@intel.com>