### PR TITLE
Fix error handling of socket descriptors, 0 is also a valid value

### DIFF
--- a/lib/wfa_tg.c
+++ b/lib/wfa_tg.c
@@ -1353,7 +1353,7 @@ int wfaSendBitrateData(int mySockfd, int streamId, BYTE *pRespBuf, int *pRespLen
 
     DPRINT_INFO(WFA_OUT, "wfaSendBitrateData entering\n");
     /* error check section  */
-    if ( (mySockfd <= 0) || (streamId < 0) || ( pRespBuf == NULL) 
+    if ( (mySockfd < 0) || (streamId < 0) || ( pRespBuf == NULL) 
             || ( pRespLen == NULL) )
     {
         DPRINT_INFO(WFA_OUT, "wfaSendBitrateData pass-in parameter err mySockfd=%i streamId=%i pRespBuf=0x%x pRespLen=0x%x\n",

--- a/lib/wfa_thr.c
+++ b/lib/wfa_thr.c
@@ -649,7 +649,7 @@ void * wfa_wmm_thread(void *thr_param)
         {
         case DIRECT_SEND:
             mySock = wfaCreateUDPSock(myProfile->sipaddr, myProfile->sport);
-            if (mySock <=0)
+            if (mySock < 0)
             {
                DPRINT_INFO(WFA_OUT, "wfa_wmm_thread SEND ERROR failed create UDP socket! \n");
                break;


### PR DESCRIPTION
Fix error handling of socket descriptors, 0 is also a valid value.

There are at least 2 instances I found where a socket descriptor value of 0 is handled as an error when in fact is perfectly valid according to the BSD socket spec.
