### PR TITLE
Fix buffer overflow that can occur in sta_set_eapaka in WTS 9.0.0

### DIFF
--- a/inc/wfa_cmds.h
+++ b/inc/wfa_cmds.h
@@ -166,7 +166,7 @@ typedef struct ca_sta_set_eapaka
 {
     char intf[WFA_IF_NAME_LEN];
     char ssid[WFA_SSID_NAME_LEN];
-    char username[32];
+    char username[64];
     char passwd[96];
     char keyMgmtType[8];
     char encrptype[9];


### PR DESCRIPTION
Member username defined in caStaSetEapAKA_t has lenght 32, but
in WTS 9.0.0 11N TC 5.2.24_ExS20 the username in sta_set_eapaka
command is longer than that, causing buffer overflow.

This patch increase the size of member username to 64.

Signed-off-by: Cedric Baudelet <cedric.baudelet@intel.com>