### PR TITLE
[HT-25]: Updated wfa_ca to send status,RUNNING to UCC if wfa_dut does…

### DIFF
--- a/ca/wfa_ca.c
+++ b/ca/wfa_ca.c
@@ -65,12 +65,13 @@ int main(int argc, char *argv[])
 {
     int nfds;
     struct sockaddr_in servAddr;
+    struct timeval tv, curr_time, start_time;
     unsigned short servPort, myport;
     char *servIP=NULL, *tstr=NULL;
     int bytesRcvd;
     fd_set sockSet;
     char cmdName[WFA_BUFF_32];
-    int i, isFound = 0, nbytes, ret_status, slen;
+    int i, isFound = 0, nbytes, ret_status, slen, st_timer = 0, st_timer_count = 1, difftime;
     WORD tag;
     int tmsockfd, cmdLen = WFA_BUFF_1K;
     int maxfdn1;
@@ -172,6 +173,8 @@ int main(int argc, char *argv[])
 
     for(;;)
         {
+            tv.tv_sec = 170;
+            tv.tv_usec = 0;
             FD_ZERO(&sockSet);
             FD_SET(tmsockfd, &sockSet);
             maxfdn1 = tmsockfd + 1;
@@ -190,7 +193,7 @@ int main(int argc, char *argv[])
                         maxfdn1 = gSock +1;
                 }
 
-            if((nfds = select(maxfdn1, &sockSet, NULL, NULL, NULL)) < 0)
+            if((nfds = select(maxfdn1, &sockSet, NULL, NULL, &tv)) < 0)
                 {
                     if(errno == EINTR)
                         continue;
@@ -226,6 +229,13 @@ int main(int argc, char *argv[])
                     memset(respStr, 0, WFA_BUFF_128);
                     sprintf(respStr, "status,RUNNING\r\n");
                     wfaCtrlSend(gCaSockfd, (BYTE *)respStr, strlen(respStr));
+					
+    	            /*
+                     * start timer to send status,RUNNING again to UCC, if DUT did not respond within 170 secs
+    	             */
+                    st_timer = 1;
+                    gettimeofday(&start_time, NULL);
+                    DPRINT_INFO(WFA_OUT, "st_timer %d\n", st_timer);
 
                     DPRINT_INFO(WFA_OUT, "%s\n", respStr);
                     DPRINT_INFO(WFA_OUT, "message %s %i\n", xcCmdBuf, nbytes);
@@ -304,6 +314,7 @@ int main(int argc, char *argv[])
                     if(isFound == 0)
                         {
                             sleep(1);
+                            st_timer = 0;
                             sprintf(respStr, "status,INVALID\r\n");
                             wfaCtrlSend(gCaSockfd, (BYTE *)respStr, strlen(respStr));
                             DPRINT_WARNING(WFA_WNG, "Command not valid, check the name\n");
@@ -314,6 +325,7 @@ int main(int argc, char *argv[])
                     if(nameStr[i].cmdProcFunc(pcmdStr, pcmdBuf, &cmdLen)==WFA_FAILURE)
                         {
                             sleep(1);
+                            st_timer = 0;
                             sprintf(respStr, "status,INVALID\r\n");
                             wfaCtrlSend(gCaSockfd, (BYTE *)respStr, strlen(respStr));
                             DPRINT_WARNING(WFA_WNG, "Incorrect command syntax\n");
@@ -325,15 +337,37 @@ int main(int argc, char *argv[])
                      */
                     if(send(gSock, pcmdBuf, cmdLen, 0) != cmdLen)
                         {
+                            st_timer = 0;
                             DPRINT_WARNING(WFA_WNG, "Incorrect sending ...\n");
                             continue;
                         }
 
                     DPRINT_INFO(WFA_OUT, "sent to DUT\n");
                 } /* done with gCaSockfd */
-
+            /* If st_timer flag is set, check if time difference is more than 170 secs and send status,RUNNING to UCC
+            If st_timer_count has reached 5, stop sending status,RUNNING to UCC. There could be some issue with wfa_dut*/
+			if(st_timer == 1)
+			    {
+					gettimeofday(&curr_time, NULL);
+					difftime = wfa_itime_diff(&start_time, &curr_time);
+                    printf("diff time %d\n", difftime);
+                    if(difftime > 170000000 && st_timer_count <= 5)
+					{
+                        memset(respStr, 0, WFA_BUFF_128);
+						sprintf(respStr, "status,RUNNING\r\n");
+						wfaCtrlSend(gCaSockfd, (BYTE *)respStr, strlen(respStr));
+                        gettimeofday(&start_time, NULL);					
+                        st_timer_count = st_timer_count + 1;
+                    }
+				}
+            else
+                {
+                    st_timer_count=0; /* Reset st_timer_count */
+                }
             if(gSock > 0 && FD_ISSET(gSock, &sockSet))
                 {
+                    st_timer = 0;
+                    DPRINT_INFO(WFA_OUT, "st_timer %d\n", st_timer);
                     DPRINT_INFO(WFA_OUT, "received from DUT\n");
                     sleep(1);
                     memset(respStr, 0, WFA_BUFF_128);


### PR DESCRIPTION
… not respond within 170 secs.

The UCC has a timeout of 3 mins. If wfa_ca doesnot respond to UCC within 3 mins, it will timeout. For certain DT profile like transaction, wfa_dut can take more time to transfer the required packets and therefore not respond within the 3 mins. So wfa_ca has been modified to send "status,RUNNING" to UCC, if wfa_dut doesnot respond with data transfer statistics within 170 secs. 

Sending "status,RUNNING" to UCC shall keep the UCC alive and UCC will continue to wait for next 3 mins.

The wfa_ca shall repeat the above steps 5 times (5*170 secs) and then it will stop sending "status,RUNNING' to UCC as there could be some issue with wfa_dut